### PR TITLE
Task: Detect pawn promotion and allow the player to select the desired piece

### DIFF
--- a/src/components/ChessBoard.jsx
+++ b/src/components/ChessBoard.jsx
@@ -49,19 +49,20 @@ const ChessBoard = () => {
     const newBoard = board.map(row => [...row]);
     const [fromRow, fromCol] = [selectedPiece.row, selectedPiece.col];
     const movingPiece = selectedPiece.piece;
+    const type = movingPiece.slice(1);
+    const color = movingPiece[0];
 
     // Handle capture
     const capturedPiece = newBoard[toRow][toCol];
     if (capturedPiece) {
-      const captureColor = movingPiece[0] === 'W' ? 'W' : 'B';
       setCapturedPieces(prev => ({
         ...prev,
-        [captureColor]: [...prev[captureColor], capturedPiece]
+        [color]: [...prev[color], capturedPiece]
       }));
     }
 
     // Handle castling
-    if (movingPiece[1] === 'king' && Math.abs(fromCol - toCol) === 2) {
+    if (type === 'king' && Math.abs(fromCol - toCol) === 2) {
       const isKingSide = toCol > fromCol;
       const rookCol = isKingSide ? 7 : 0;
       const newRookCol = isKingSide ? 5 : 3;
@@ -70,13 +71,13 @@ const ChessBoard = () => {
     }
 
     // Handle en passant
-    if (movingPiece[1] === 'pawn' && Math.abs(fromCol - toCol) === 1 && newBoard[toRow][toCol] === '') {
+    if (type === 'pawn' && Math.abs(fromCol - toCol) === 1 && newBoard[toRow][toCol] === '') {
       const capturedPawnRow = fromRow;
       const capturedPawn = newBoard[capturedPawnRow][toCol];
       newBoard[capturedPawnRow][toCol] = '';
       setCapturedPieces(prev => ({
         ...prev,
-        [movingPiece[0]]: [...prev[movingPiece[0]], capturedPawn]
+        [color]: [...prev[color], capturedPawn]
       }));
     }
 
@@ -85,16 +86,15 @@ const ChessBoard = () => {
     newBoard[fromRow][fromCol] = '';
 
     // Pawn promotion
-    if (movingPiece[1] === 'pawn' && (toRow === 0 || toRow === 7)) {
-      newBoard[toRow][toCol] = movingPiece[0] + 'queen';
+    if (type === 'pawn' && (toRow === 0 || toRow === 7)) {
+      newBoard[toRow][toCol] = color + 'queen';
     }
 
     // Update castling rights
     updateCastlingRights(movingPiece, fromRow, fromCol);
-
     // Set en passant target
     setEnPassantTarget(
-      movingPiece[1] === 'pawn' && Math.abs(fromRow - toRow) === 2
+      type === 'pawn' && Math.abs(fromRow - toRow) === 2
         ? { row: (fromRow + toRow) / 2, col: toCol }
         : null
     );
@@ -219,7 +219,7 @@ const ChessBoard = () => {
       if (!castlingRights[color][isKingSide ? 'kingSide' : 'queenSide']) return false;
       
       const rookCol = isKingSide ? 7 : 0;
-      if (board[startRow][rookCol][1] !== 'rook') return false;
+      if (board[startRow][rookCol].slice(1) !== 'rook') return false;
 
       const direction = isKingSide ? 1 : -1;
       for (let i = startCol + direction; i !== rookCol; i += direction) {
@@ -296,6 +296,7 @@ const ChessBoard = () => {
     return false;
   };
 
+  
   const updateCastlingRights = (piece, fromRow, fromCol) => {
     const newCastlingRights = { ...castlingRights };
     const color = piece[0];

--- a/src/components/ChessBoard.jsx
+++ b/src/components/ChessBoard.jsx
@@ -29,7 +29,7 @@ const ChessBoard = () => {
   }, [turn]);
 
   const handleClick = (row, col) => {
-    if (gameStatus !== 'ongoing') return;
+    if (gameStatus === 'checkmate' || gameStatus === 'stalemate') return;
 
     if (selectedPiece) {
       if (isLegalMove(selectedPiece.row, selectedPiece.col, row, col)) {

--- a/src/components/ChessBoard.jsx
+++ b/src/components/ChessBoard.jsx
@@ -299,12 +299,12 @@ const ChessBoard = () => {
   
   const updateCastlingRights = (piece, fromRow, fromCol) => {
     const newCastlingRights = { ...castlingRights };
+    const type = piece.slice(1);
     const color = piece[0];
-
-    if (piece[1] === 'king') {
+    if (type === 'king') {
       newCastlingRights[color].kingSide = false;
       newCastlingRights[color].queenSide = false;
-    } else if (piece[1] === 'rook') {
+    } else if (type === 'rook') {
       if (fromCol === 0) newCastlingRights[color].queenSide = false;
       if (fromCol === 7) newCastlingRights[color].kingSide = false;
     }

--- a/todo.md
+++ b/todo.md
@@ -3,6 +3,6 @@ Issues
 [X] When Black checks white, it throws checkmate even if there is legal moves
 [X] En passant not working
 [X] Fix castling not working
-[ ] When black checks white with the beshop white can only protect by move the king, not the other pieces that could capture the beshop or act as barrier
+[ ] when king is in check, moving a piece in front of the king isn't a valid move
 [X] Implement promotion functionality
-[ ] Bug: the promoted piece isn't checking in the king after being promoted
+[ ] Bug: isLegalMove has circular dependency causing infinite loop 

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,10 @@
+Issues
+[ ] When White checks Black, black can't move even if there is still legal moves
+[ ] When Black checks white, it throws checkmate even if there is legal moves
+[ ] Wgeb black checks white with the beshop white can only protect by move the king, not the other pieces that could capture the beshop or act as barrier
+[ ] Implement 
+[ ] En passant not working
+[ ] Fix castling not working
+
+
+[ ] normalize all code to use piece.slice(1) as to extract the piece

--- a/todo.md
+++ b/todo.md
@@ -1,10 +1,8 @@
 Issues
-[ ] When White checks Black, black can't move even if there is still legal moves
-[ ] When Black checks white, it throws checkmate even if there is legal moves
-[ ] Wgeb black checks white with the beshop white can only protect by move the king, not the other pieces that could capture the beshop or act as barrier
-[ ] Implement 
-[ ] En passant not working
-[ ] Fix castling not working
-
-
-[ ] normalize all code to use piece.slice(1) as to extract the piece
+[X] When White checks Black, black can't move even if there is still legal moves
+[X] When Black checks white, it throws checkmate even if there is legal moves
+[X] En passant not working
+[X] Fix castling not working
+[ ] When black checks white with the beshop white can only protect by move the king, not the other pieces that could capture the beshop or act as barrier
+[X] Implement promotion functionality
+[ ] Bug: the promoted piece isn't checking in the king after being promoted


### PR DESCRIPTION
 Implement Pawn Promotion

In chess, when a pawn reaches the opponent's back rank (8th for white, 1st for black), it must be promoted to Queen, Rook, Knight, or Bishop.

    Task: Detect pawn promotion and allow the player to select the desired piece.
    Validation: Ensure the promoted piece behaves correctly according to chess rules.
